### PR TITLE
Refactor LCD driver includes to use conditional compilation

### DIFF
--- a/stm32h747i_discovery_lcd.h
+++ b/stm32h747i_discovery_lcd.h
@@ -30,11 +30,15 @@
 #include "stm32h747i_discovery_errno.h"
 #include "lcd.h"
 
+#if (USE_LCD_CTRL_NT35510 == 1)
 /* Include NT35510 LCD Driver IC driver code */
 #include "../Components/nt35510/nt35510.h"
+#endif /* USE_LCD_CTRL_NT35510 */
 
+#if (USE_LCD_CTRL_OTM8009A == 1)
 /* Include OTM8009A LCD Driver IC driver code */
 #include "../Components/otm8009a/otm8009a.h"
+#endif /* USE_LCD_CTRL_OTM8009A */
 
 #if (USE_LCD_CTRL_ADV7533 == 1)
 /* Include ADV7533 HDMI Driver IC driver code */


### PR DESCRIPTION
This change updates the inclusion of LCD driver headers (`NT35510`, `OTM8009A`, and `ADV7533`) to use conditional compilation macros (`USE_LCD_CTRL_*`). Based on the configuration, this ensures that only the necessary driver code is included, improving modularity and build efficiency.

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](CONTRIBUTING.md) file.
