### PR TITLE
Fix typo in RecordPDM Parameters

### DIFF
--- a/stm32h747i_discovery_audio.c
+++ b/stm32h747i_discovery_audio.c
@@ -2072,7 +2072,7 @@ int32_t BSP_AUDIO_IN_Resume(uint32_t Instance)
 
 /**
   * @brief  Start audio recording.
-  * @param  Instance  AUDIO IN SAI PDM Instance. It can be only 2
+  * @param  Instance  AUDIO IN SAI PDM Instance. It can only be 1
   * @param  pBuf     Main buffer pointer for the recorded data storing
   * @param  NbrOfBytes  Size of the record buffer
   * @retval BSP status


### PR DESCRIPTION
Simple typo when describing the Instance parameter in BSP_AUDIO_IN_RecordPDM(). If the instance is selected as 2 like the docstring specifies the code will return BSP_ERROR_WRONG_PARAM.
